### PR TITLE
Set filetype to floating window's buffer from parent buffer's filetype

### DIFF
--- a/lua/sig-window-nvim.lua
+++ b/lua/sig-window-nvim.lua
@@ -81,6 +81,7 @@ local function show_signature_window(label, active_ix_start, active_ix_end, conf
 
   vim.api.nvim_win_set_option(winnr, 'wrap', true)
   vim.api.nvim_win_set_option(winnr, 'foldenable', false)
+  vim.api.nvim_buf_set_option(w_bufnr, 'filetype', vim.bo[bufnr].filetype)
   vim.api.nvim_buf_set_option(w_bufnr, 'modifiable', false)
   vim.api.nvim_buf_set_option(w_bufnr, 'bufhidden', 'wipe')
   vim.api.nvim_buf_set_var(bufnr, 'sig-window-nvim', winnr)


### PR DESCRIPTION
This pr adds syntax highlighting for the floating signature window.

before:

<img width="590" alt="image" src="https://github.com/erhickey/sig-window-nvim/assets/1687443/b8ef209d-0015-4dc5-8dfb-91a2ea8e8c2f">

after:

<img width="629" alt="image" src="https://github.com/erhickey/sig-window-nvim/assets/1687443/6d32848c-a573-4144-a1d3-d488d1157417">
