### PR TITLE
bugfix: split lines before calling nvim_buf_set_lines

### DIFF
--- a/lua/sig-window-nvim.lua
+++ b/lua/sig-window-nvim.lua
@@ -81,9 +81,9 @@ local function show_signature_window(label, active_ix_start, active_ix_end, conf
   local bufnr = vim.api.nvim_get_current_buf()
   local w_bufnr = vim.api.nvim_create_buf(false, true)
 
-  local all_labels = {label}
+  local all_labels = vim.split(label, "\n", { plain = true })
   for i, v in ipairs(other_labels) do
-    all_labels[i + 1] = v
+    vim.list_extend(all_labels, vim.split(v, "\n", { plain = true }))
   end
 
   vim.api.nvim_buf_set_lines(w_bufnr, 0, -1, true, all_labels)


### PR DESCRIPTION
### bug snapshot

<img width="1186" alt="image" src="https://github.com/user-attachments/assets/03b3826a-ba2d-4527-a6b2-9edfb65521ef" />

### source code reproducing

Neovim:

```
NVIM v0.10.3
Build type: Release
LuaJIT 2.1.1713484068
Run "nvim -V1 -v" for more info
```

My Lua configs

```lua
require('sig-window-nvim').setup({
  window_config = function(label, config, width, height)
    return {
      relative = 'cursor',
      anchor = 'SW',
      width = width,
      height = height,
      row = -1,
      col = 3,
      focusable = false,
      zindex = config.zindex,
      style = 'minimal',
      border = config.border,
    }
  end,
  border = 'single',
  hl_group = 'Visual',
})

```

Place cursor at line 11, around `async_read_until(`, will trigger this error:

```cpp
#include <asio.hpp>
#include <iostream>
#include <string>
#include <thread>

asio::awaitable<void> session(asio::ip::tcp::socket socket) {
  try {
    std::string data;
    auto buffer = asio::dynamic_buffer(data);
    for (;;) {
      std::size_t bytes_transferred = co_await asio::async_read_until(
          socket, buffer, '\n', asio::use_awaitable);
      std::string line{static_cast<const char *>(data.data()),
                       bytes_transferred};
      std::cout << line << std::endl;
      buffer.consume(bytes_transferred);

      co_await asio::async_write(socket, asio::buffer(line),
                                 asio::use_awaitable);
    }
  } catch (std::exception &e) {
    std::cerr << "Exception in session: " << e.what() << std::endl;
  }
  co_return;
}

asio::awaitable<void> listener() {
  auto executor = co_await asio::this_coro::executor;
  asio::ip::tcp::acceptor acceptor(executor, {asio::ip::tcp::v4(), 55551});
  std::cout << "Server listening on port 55551" << std::endl;
  for (;;) {
    asio::ip::tcp::socket socket =
        co_await acceptor.async_accept(asio::use_awaitable);
    asio::co_spawn(executor, session(std::move(socket)), asio::detached);
  }
}

int main() {
  asio::io_context io_context;
  asio::thread_pool pool(std::thread::hardware_concurrency());
  asio::co_spawn(pool, listener, asio::detached);
  io_context.run();
  pool.join();
  return 0;
}

```

### fixes description

The labels may contain newlines.

I think we should split into lines, and add lines (not labels) to the table before calling `nvim_buf_set_lines`
